### PR TITLE
Feat/increase subscriber queue size MOVEMENT-1692

### DIFF
--- a/src/lib/ActionClientInterface.js
+++ b/src/lib/ActionClientInterface.js
@@ -41,29 +41,29 @@ class ActionClientInterface extends EventEmitter {
 
     const nh = options.nh;
 
-    const goalOptions = Object.assign({ queueSize: 10, latching: true }, options.goal);
+    const goalOptions = Object.assign({ queueSize: 50, latching: true }, options.goal);
     this._goalPub = nh.advertise(this._actionServer + '/goal',
                                  this._actionType + 'Goal',
                                  goalOptions);
 
-    const cancelOptions = Object.assign({ queueSize: 10, latching: true }, options.cancel);
+    const cancelOptions = Object.assign({ queueSize: 50, latching: true }, options.cancel);
     this._cancelPub = nh.advertise(this._actionServer + '/cancel',
                                    'actionlib_msgs/GoalID',
                                    cancelOptions);
 
-    const statusOptions = Object.assign({ queueSize: 25 }, options.status);
+    const statusOptions = Object.assign({ queueSize: 50 }, options.status);
     this._statusSub = nh.subscribe(this._actionServer + '/status',
                                    'actionlib_msgs/GoalStatusArray',
                                    (msg) => { this._handleStatus(msg); },
                                    statusOptions);
 
-    const feedbackOptions = Object.assign({ queueSize: 25 }, options.feedback);
+    const feedbackOptions = Object.assign({ queueSize: 50 }, options.feedback);
     this._feedbackSub = nh.subscribe(this._actionServer + '/feedback',
                                      this._actionType + 'Feedback',
                                      (msg) => { this._handleFeedback(msg); },
                                      feedbackOptions);
 
-    const resultOptions = Object.assign({ queueSize: 25 }, options.result);
+    const resultOptions = Object.assign({ queueSize: 50 }, options.result);
     this._resultSub = nh.subscribe(this._actionServer + '/result',
                                    this._actionType + 'Result',
                                    (msg) => { this._handleResult(msg); },

--- a/src/lib/ActionClientInterface.js
+++ b/src/lib/ActionClientInterface.js
@@ -51,19 +51,19 @@ class ActionClientInterface extends EventEmitter {
                                    'actionlib_msgs/GoalID',
                                    cancelOptions);
 
-    const statusOptions = Object.assign({ queueSize: 1 }, options.status);
+    const statusOptions = Object.assign({ queueSize: 25 }, options.status);
     this._statusSub = nh.subscribe(this._actionServer + '/status',
                                    'actionlib_msgs/GoalStatusArray',
                                    (msg) => { this._handleStatus(msg); },
                                    statusOptions);
 
-    const feedbackOptions = Object.assign({ queueSize: 1 }, options.feedback);
+    const feedbackOptions = Object.assign({ queueSize: 25 }, options.feedback);
     this._feedbackSub = nh.subscribe(this._actionServer + '/feedback',
                                      this._actionType + 'Feedback',
                                      (msg) => { this._handleFeedback(msg); },
                                      feedbackOptions);
 
-    const resultOptions = Object.assign({ queueSize: 1 }, options.result);
+    const resultOptions = Object.assign({ queueSize: 25 }, options.result);
     this._resultSub = nh.subscribe(this._actionServer + '/result',
                                    this._actionType + 'Result',
                                    (msg) => { this._handleResult(msg); },


### PR DESCRIPTION
The default queue sizes for both publishers and subscribers are set to 50 in actionlib and we dont overwrite those values: https://github.com/ros/actionlib/blob/c3b2bd84f07ff54c36033c92861d3b63b7420590/actionlib/include/actionlib/server/action_server_imp.h#L143Bringing these values up to par with those set in the actionlib.