### PR TITLE
fix: latched subs

### DIFF
--- a/src/lib/RosNode.js
+++ b/src/lib/RosNode.js
@@ -115,7 +115,7 @@ class RosNode extends EventEmitter {
     if (!subImpl) {
       subImpl = new SubscriberImpl(options, this);
       this._subscribers[topic] = subImpl;
-      this.first = true;
+      this.firstSubscriber = true;
     }
 
     const sub = new Subscriber(subImpl);

--- a/src/lib/RosNode.js
+++ b/src/lib/RosNode.js
@@ -111,14 +111,19 @@ class RosNode extends EventEmitter {
   subscribe(options, callback) {
     let topic = options.topic;
     let subImpl = this._subscribers[topic];
+    let firstSubscriber = false;
     if (!subImpl) {
       subImpl = new SubscriberImpl(options, this);
       this._subscribers[topic] = subImpl;
+      this.first = true;
     }
 
     const sub = new Subscriber(subImpl);
     if (callback && typeof callback === 'function') {
       sub.on('message', callback);
+    }
+    if (!firstSubscriber && subImpl._latching && subImpl._lastMessage){
+        sub.emit('message', subImpl._lastMessage)
     }
 
     return sub;

--- a/src/lib/RosNode.js
+++ b/src/lib/RosNode.js
@@ -122,8 +122,10 @@ class RosNode extends EventEmitter {
     if (callback && typeof callback === 'function') {
       sub.on('message', callback);
     }
-    if (!firstSubscriber && subImpl._latching && subImpl._lastMessage){
-        sub.emit('message', subImpl._lastMessage)
+    // Duplicate subscribers wont get a latched 'message' emit from the existing subscriber impl.
+    // This will forcibly send an emit if the topic is latched and has already seen an incoming message
+    if (!firstSubscriber && subImpl.getLatching() && subImpl.getLastMessage()) {
+        sub.emit('message', subImpl.getLastMessage())
     }
 
     return sub;

--- a/src/lib/RosNode.js
+++ b/src/lib/RosNode.js
@@ -115,7 +115,7 @@ class RosNode extends EventEmitter {
     if (!subImpl) {
       subImpl = new SubscriberImpl(options, this);
       this._subscribers[topic] = subImpl;
-      this.firstSubscriber = true;
+      firstSubscriber = true;
     }
 
     const sub = new Subscriber(subImpl);

--- a/src/lib/impl/SubscriberImpl.js
+++ b/src/lib/impl/SubscriberImpl.js
@@ -85,6 +85,11 @@ class SubscriberImpl extends EventEmitter {
     this._pendingPubClients = {};
 
     this._state = REGISTERING;
+
+    this._latching = undefined;
+
+    this._lastMessage = undefined;
+  
     this._register();
   }
 
@@ -389,6 +394,10 @@ class SubscriberImpl extends EventEmitter {
     // remove client from pending map now that it's validated
     delete this._pendingPubClients[client.nodeUri];
 
+    if (header.latching) {
+      this._latching = true;
+    }
+
     // pipe all future messages to _handleMessage
     client.$deserializer.on('message', this._handleMessage.bind(this));
 
@@ -416,6 +425,9 @@ class SubscriberImpl extends EventEmitter {
   _handleMsgQueue(msgQueue) {
     try {
       msgQueue.forEach((msg) => {
+        if(this._latching){
+          this._lastMessage = this._messageHandler.deserialize(msg);
+        }
         this.emit('message', this._messageHandler.deserialize(msg));
       });
     }

--- a/src/lib/impl/SubscriberImpl.js
+++ b/src/lib/impl/SubscriberImpl.js
@@ -135,6 +135,23 @@ class SubscriberImpl extends EventEmitter {
   }
 
   /**
+   * Check if this subscriber is connected to a latched topic
+   * @returns {boolean}
+   */
+  getLatching() {
+    return this._latching;
+  }
+
+  /**
+   * Return the last message received
+   * @returns {any}
+   */
+  getLastMessage() {
+    return this._lastMessage;
+  }
+
+
+  /**
    * Clears and closes all client connections for this subscriber.
    */
   shutdown() {
@@ -425,7 +442,7 @@ class SubscriberImpl extends EventEmitter {
   _handleMsgQueue(msgQueue) {
     try {
       msgQueue.forEach((msg) => {
-        if(this._latching){
+        if (this.getLatching()) {
           this._lastMessage = this._messageHandler.deserialize(msg);
         }
         this.emit('message', this._messageHandler.deserialize(msg));

--- a/test/xmlrpcTest.js
+++ b/test/xmlrpcTest.js
@@ -740,7 +740,7 @@ describe('Protocol Test', () => {
       });
     });
 
-    it.only('2 Subscribers on Same Latched Topic subscribing at different times ', function(done) {
+    it('2 Subscribers on Same Latched Topic subscribing at different times ', function(done) {
       this.slow(1000);
       const nh = rosnodejs.nh;
 

--- a/test/xmlrpcTest.js
+++ b/test/xmlrpcTest.js
@@ -739,6 +739,30 @@ describe('Protocol Test', () => {
         });
       });
     });
+
+    it.only('2 Subscribers on Same Latched Topic subscribing at different times ', function(done) {
+      this.slow(1000);
+      const nh = rosnodejs.nh;
+
+      let msg1;
+      const sub1 = nh.subscribe(topic, msgType, (msg) => {
+        msg1 = msg.data;
+        let msg2;
+        const sub2 = nh.subscribe(topic, msgType, (msg) => {
+          expect(sub1._impl.listenerCount('connection')).to.equal(2);
+          msg2 = msg.data;
+          expect(msg1).to.equal(1);
+          expect(msg1).to.equal(msg2);
+          done()
+        });
+      });
+
+      expect(sub1._impl.listenerCount('connection')).to.equal(1);
+
+      const pub = nh.advertise(topic, msgType, {latching: true});
+
+      pub.publish({data: 1});
+    });
   });
 
   describe('Service', () => {


### PR DESCRIPTION
If a connection makes a duplicate subscriber, and the publisher is latched, send the last message it was sent